### PR TITLE
Python build error fix

### DIFF
--- a/source-builder/config/gdb-common-1.cfg
+++ b/source-builder/config/gdb-common-1.cfg
@@ -81,6 +81,8 @@
  %define gdb-python-config %(command -v %{gdb-enable-python}-config || true)
 %endif
 %define gdb-python-ver-mm %(%{gdb-enable-python} --version 2>&1 | sed -e 's/.* //g' | rev | cut -d'.' -f2- | rev)
+%define gdb-python-ver-major %(echo "%{gdb-python-ver-mm}" | sed -e 's/\..*//')
+%define gdb-python-ver-minor %(echo "%{gdb-python-ver-mm}" | sed -e 's/.*\.//')
 %define gdb-python-header Python.h
 %define gdb-python-ver-header python%{gdb-python-ver-mm}/%{gdb-python-header}
 %define gdb-python-ver-lib libpython%{gdb-python-ver-mm}.*
@@ -109,7 +111,8 @@
   %endif
   %if %{gdb-python-config} != %{nil}
     %define gdb-python-lib-filter awk 'BEGIN{FS=" "}/python/{for(i=1;i<NF;++i)if(match($i,".*lpython.*")) print "lib"substr($i,3)"*";}'
-    %if %{gdb-python-ver-mm} < 3.8
+    %if %{gdb-python-ver-major} < 3 || \
+        %{gdb-python-ver-major} == 3 && %{gdb-python-ver-minor} < 8
         %define gdb-python-config-lib-check-flags --ldflags
     %else
         %define gdb-python-config-lib-check-flags --ldflags --embed


### PR DESCRIPTION
This cherry-picks two commits to fix a Python-related build error when the installed Python version is 3.8 or newer.
Fixes grisp/grisp2-rtems-toolchain#43